### PR TITLE
Fix: Dark mode functionality missing from Services page (#35).

### DIFF
--- a/service.html
+++ b/service.html
@@ -227,3 +227,7 @@
   <script src="js/jquery-3.4.1.min.js"></script>
   <script src="js/bootstrap.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js">
+  </script> <script src="js/custom.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR resolves an issue where the Service page lacked dark mode support due to a missing JavaScript line.
Added the required script to ensure consistent dark mode behavior across the page.

Changes:
Included the JavaScript responsible for toggling dark mode.

Issue: Fixes #35