### PR TITLE
Fix: Restored lost FAQ section in service.html (#65) 

### DIFF
--- a/service.html
+++ b/service.html
@@ -180,6 +180,90 @@
   </section>
   <!-- End Services Section -->
 
+   <!-- FAQ Section -->
+  <section class="faq_section mt-5 mb-5">
+    <div class="container">
+      <div class="heading_container">
+        <h2>Service FAQs</h2>
+        <p>Here are some common questions we receive about our services.</p>
+      </div>
+
+      <div class="accordion mt-4" id="serviceFaqs">
+        <!-- FAQ 1 -->
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="faqOneH">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#faqOne"
+              aria-expanded="true" aria-controls="faqOne">
+              Do you provide same-day service for urgent home maintenance issues?
+            </button>
+          </h2>
+          <div id="faqOne" class="accordion-collapse collapse show" aria-labelledby="faqOneH" data-bs-parent="#serviceFaqs">
+            <div class="accordion-body">
+              Yes! We offer same-day slots for plumbing leaks, electrical problems, and minor repairs. Early booking improves availability for urgent cases.
+            </div>
+          </div>
+        </div>
+        <!-- FAQ 2 -->
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="faqTwoH">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqTwo"
+              aria-expanded="false" aria-controls="faqTwo">
+              What’s included in your deep cleaning service?
+            </button>
+          </h2>
+          <div id="faqTwo" class="accordion-collapse collapse" aria-labelledby="faqTwoH" data-bs-parent="#serviceFaqs">
+            <div class="accordion-body">
+              Our deep cleaning service covers every room, including bathrooms, kitchens, appliances (external), carpets, and windows. Add-ons like sofa shampooing or inside-appliance cleaning can be requested.
+            </div>
+          </div>
+        </div>
+        <!-- FAQ 3 -->
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="faqThreeH">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqThree"
+              aria-expanded="false" aria-controls="faqThree">
+              How do you estimate the cost for renovation and painting work?
+            </button>
+          </h2>
+          <div id="faqThree" class="accordion-collapse collapse" aria-labelledby="faqThreeH" data-bs-parent="#serviceFaqs">
+            <div class="accordion-body">
+              We begin with a free on-site assessment to measure the area and check wall condition. A clear estimate is then shared with labor, paint, and material costs.
+            </div>
+          </div>
+        </div>
+        <!-- FAQ 4 -->
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="faqFourH">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqFour"
+              aria-expanded="false" aria-controls="faqFour">
+              Can you repair all types of home appliances?
+            </button>
+          </h2>
+          <div id="faqFour" class="accordion-collapse collapse" aria-labelledby="faqFourH" data-bs-parent="#serviceFaqs">
+            <div class="accordion-body">
+              Yes, we service all major brands and types, including ACs, washing machines, refrigerators, and microwaves. All repairs come with a service warranty.
+            </div>
+          </div>
+        </div>
+        <!-- FAQ 5 -->
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="faqFiveH">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faqFive"
+              aria-expanded="false" aria-controls="faqFive">
+              Do you help with IT network setup for small offices and homes?
+            </button>
+          </h2>
+          <div id="faqFive" class="accordion-collapse collapse" aria-labelledby="faqFiveH" data-bs-parent="#serviceFaqs">
+            <div class="accordion-body">
+              Absolutely! We handle Wi-Fi setup, printer installation, and basic network configuration. We can also suggest the best hardware for your needs.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- End FAQ Section -->
+   
   <!-- Footer -->
   <section class="new-info-section">
     <div class="new-container">


### PR DESCRIPTION
Hi @sumitrathor1 
This PR restores the FAQ section that was unintentionally removed during conflict resolution in PR #. The original section, which used Bootstrap accordion, has been re-added to `service.html` just below the Services section.
Closes #65 

<img width="1909" height="930" alt="Screenshot 2025-07-31 212631" src="https://github.com/user-attachments/assets/6d19d4e3-8f34-4af6-ac8d-ea570e0f54aa" />

<img width="1891" height="905" alt="Screenshot 2025-07-31 212656" src="https://github.com/user-attachments/assets/30207fc1-591a-4f4d-a9bb-2054f41156b4" />

I understand that the issue is not assigned to me yet, but since the mistake was from my side and I already had prior context, I went ahead and restored the lost section.

Kindly review the PR and let me know if it can be accepted under GSSoC'25. Thank you for allowing me to correct the mistake!



