### PR TITLE
Implemented dark mode in services page, fixed dark mode visibility issues

### DIFF
--- a/about.html
+++ b/about.html
@@ -80,6 +80,14 @@
                 <li class="nav-item"><a class="nav-link" href="service.html">Services</a></li>
                 <li class="nav-item"><a class="nav-link" href="contributors.html">Contributors</a></li>
                 <li class="nav-item contact-highlight"><a class="nav-link" href="contact.html">Contact Us</a></li>
+                <li class="nav-item">
+                  <label class="switch theme-switch">
+                  <input type="checkbox" id="theme-toggle">
+                  <span class="slider">
+                    <i class="fas fa-sun sun-icon"></i>
+                    <i class="fas fa-moon moon-icon"></i>
+                  </span>
+                </label>
               </ul>
             </div>
           </nav>

--- a/css/style.css
+++ b/css/style.css
@@ -1303,6 +1303,19 @@ body {
   color: white;
 }
 
+.slider i{
+  color:#e9ecef;
+}
+
+.carousel-wrap_layout_padding2-top{
+  background-color: #94c3d3;
+  color: white;
+}
+
+.client-section p{
+  color: #ffffff;
+}
+
 /* Navbar */
 [data-theme="dark"] .navbar {
   background-color: #1a1a1a;
@@ -1313,8 +1326,56 @@ body {
   color: white;
 }
 
+[data-theme="dark"] .container-1 .detail-box p{
+  color: black;
+}
+
+[data-theme="dark"] .container-1 .detail-box h5{
+  color: black;
+}
+
+[data-theme="dark"] .container-3 .detail-box p{
+  color: black;
+}
+
+[data-theme="dark"] .container-2 .detail-box h2,a{
+  color: rgb(245, 239, 239);
+  margin-left: 40px;
+}
+
+[data-theme="dark"] .container-2 .detail-box p{
+  color: rgb(245, 239, 239);
+  margin-left: 40px;
+}
+
+[data-theme="dark"] .box .client_text1 {
+  color: rgb(245, 239, 239);
+}
+
+.client_section .container {
+  background-color: #c1e3e6;
+  color: #000;
+}
+
+[data-theme="light"] .container-2 .detail-box h2,p,a{
+  color: rgb(12, 12, 12);
+  margin-left: 40px;
+}
+
 body, .hero, .navbar, .btn-primary {
   transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+[data-theme="dark"] .about_section_layout_padding .heading_container p{
+  color: #ffffff;
+}
+
+[data-theme="dark"] .about_section_layout_padding .row h5{
+  color: #070707;
+}
+
+[data-theme="dark"] .about_section .detail-box p{
+  color: #f7efef;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 
   <!-- about section -->
   <section class="about_section layout_padding-bottom">
-    <div class="container">
+    <div class="container-2">
       <div class="row">
         <div class="col-lg-5 col-md-6">
           <div class="detail-box">
@@ -154,7 +154,7 @@
 
   <!-- professional section -->
   <section class="professional_section layout_padding">
-    <div class="container">
+    <div class="container-3">
       <div class="row">
         <div class="col-md-6">
           <div class="img-box">
@@ -178,7 +178,7 @@
 
   <!-- service section -->
   <section class="service_section layout_padding">
-    <div class="container">
+    <div class="container-1">
       <div class="heading_container heading_center">
         <h2>Our Services</h2>
       </div>
@@ -255,7 +255,7 @@
               <i class="fa fa-quote-left" aria-hidden="true"></i>
             </div>
           </div>
-          <div class="client_text">
+          <div class="client_text1">
             <p>
               "At Sachiva, we believe in leveraging technology to empower businesses and individuals.
               Our mission is to provide top-notch IT solutions, ensuring security, innovation, and
@@ -276,7 +276,7 @@
                     What Our Clients Say
                 </h2>
             </div>
-            <div class="carousel-wrap layout_padding2-top ">
+            <div class="carousel-wrap_layout_padding2-top ">
                 <div class="owl-carousel">
                     <div class="item">
                         <div class="box">

--- a/service.html
+++ b/service.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 
 <head>
   <!-- Basic Meta -->
@@ -96,6 +96,14 @@
                 <li class="nav-item active fw-bold"><a class="nav-link" href="service.html">Services <span class="sr-only">(current)</span></a></li>
                 <li class="nav-item"><a class="nav-link" href="contributors.html">Contributors</a></li>
                 <li class="nav-item contact-highlight"><a class="nav-link" href="contact.html">Contact Us</a></li>
+                <li class="nav-item">
+                  <label class="switch theme-switch">
+                  <input type="checkbox" id="theme-toggle">
+                  <span class="slider">
+                    <i class="fas fa-sun sun-icon"></i>
+                    <i class="fas fa-moon moon-icon"></i>
+                  </span>
+                </label>
               </ul>
             </div>
           </nav>


### PR DESCRIPTION
 Improvements Done:

1. Implemented dark mode styling for the dedicated **Our Services** page which was previously not switching themes.
2. Fixed text visibility issues on the **About Us** page while using dark mode.
3. Ensured proper dark mode display across all sections of the **Home Page** (e.g., hero, professional, and services sections) — all previously hidden white-on-white text is now clearly visible.
4. Added **Dark/Light Mode Toggle** to both **About** and **Services** pages (previously missing).

📝 Kindly review and merge the PR.  
If possible, I also request you to **update my GitHub profile** in the **Contributors** section of the website — the current account linked is temporary and not my permanent one.
please consider adding this account == https://github.com/Likitha-projects

Thanks for your support!