### PR TITLE
Solved overlapping issue

### DIFF
--- a/service.html
+++ b/service.html
@@ -30,6 +30,10 @@
     font-weight: bolder;
   }
 
+  .heading{
+    margin-top: 50px;
+  }
+
   .whatsapp {
     position: fixed;
     bottom: 20px;
@@ -121,7 +125,7 @@
 <section class="about_section_layout_padding">
   <div class="container">
     <div class="heading_container">
-      <h2>Our Services</h2>
+      <h2 class="heading">Our Services</h2>
 
       <div class="filter-buttons mb-4 text-center">
         <button id="all-btn" class="btn btn-outline-primary filter-btn active" data-filter="all">All</button>


### PR DESCRIPTION
This PR solves the overlapping issue of the Our Services header in the services page with the navigation bar at the top.
fixes #95 

## Screenshot

Before:
<img width="644" height="193" alt="image" src="https://github.com/user-attachments/assets/1b74bd29-d19b-420b-9126-c1bbfb508072" />


After:
<img width="889" height="253" alt="image" src="https://github.com/user-attachments/assets/8d98f3e7-3b1a-4d81-919f-f8767a2df8ac" />
