### PR TITLE
Fix: Added space in 'OUR LATESTBLOG' heading to 'OUR LATEST BLOG'

### DIFF
--- a/html/blog.html
+++ b/html/blog.html
@@ -146,7 +146,7 @@
 <section class="blog_section layout_padding" id="blog">
   <div class="container">
     <div class="heading_container heading_center">
-      <h2 class="wow animate__animated animate__fadeInDown">Our Latest <span>Blog</span></h2>
+      <h2 class="wow animate__animated animate__fadeInDown">Our Latest Blog</h2>
       <p class="wow animate__animated animate__fadeIn">Explore insightful reads and stories from our team.</p>
     </div>
 


### PR DESCRIPTION
This pull request fixes a minor UI issue in the blog section heading. The heading previously displayed as:
OUR LATESTBLOG

This has been corrected to:
OUR LATEST BLOG
<img width="1900" height="770" alt="Screenshot 2025-08-08 203200" src="https://github.com/user-attachments/assets/a5a18abd-2bcb-47bf-867c-aaf647e9a296" />

The change improves readability and ensures consistency with standard grammar and UI text styling.

Solves issue (#144 )