### PR TITLE
Fixed Cards Allignment

### DIFF
--- a/html/portfolio.html
+++ b/html/portfolio.html
@@ -379,6 +379,7 @@
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
<h1>Description</h1>

Issue #203 

- Fixed the spacing by adding justify-content :space between
- All Cards are now on same horizontal level


<h1>Before</h1>
<img width="1898" height="910" alt="Screenshot 2025-08-18 232747" src="https://github.com/user-attachments/assets/a9a65990-743d-4d29-b7b4-60fee622925b" />


<h1>After</h1>

https://github.com/user-attachments/assets/c7c6972c-2c2e-4ef3-9db9-e8548bf89a47

