### PR TITLE
Fix: Prevent first FAQ from auto-expanding on page load

### DIFF
--- a/html/service.html
+++ b/html/service.html
@@ -1085,6 +1085,24 @@
     </section>
     <!-- End FAQ Section -->
 
+    <script>
+  document.addEventListener("DOMContentLoaded", function () {
+    // Select all accordion buttons
+    const accordionButtons = document.querySelectorAll(".accordion-button");
+    accordionButtons.forEach((btn) => {
+      btn.classList.add("collapsed");
+      btn.setAttribute("aria-expanded", "false");
+    });
+
+    // Select all accordion collapse elements
+    const accordionItems = document.querySelectorAll(".accordion-collapse");
+    accordionItems.forEach((item) => {
+      item.classList.remove("show");
+    });
+  });
+</script>
+
+
     <!-- Footer -->
     <!-- Footer -->
     <footer class="custom-footer">


### PR DESCRIPTION
#235 Description:
This PR resolves the issue where the first FAQ item (FAQ 1) would auto-expand on page load, even after manually collapsing it.

Changes Made:
Added a small JavaScript snippet that ensures all FAQ items are collapsed by default when the page loads.
Reset aria-expanded and collapsed states for all accordion buttons.
Removed any unintended default expansion behavior caused by the show class.

Result:
All FAQ items remain collapsed by default when the FAQ section loads.
They now only expand/collapse when clicked by the user.
After refresh, the default collapsed state is preserved.

<img width="1919" height="1079" alt="Screenshot 2025-08-27 075540" src="https://github.com/user-attachments/assets/b260b37e-b56a-45d5-9fd8-beeda36b7166" />
